### PR TITLE
fix(#93): the evaluation chaining operation must stop when reach a trigger target status

### DIFF
--- a/core/src/main/java/io/github/zero88/schedulerx/impl/AbstractScheduler.java
+++ b/core/src/main/java/io/github/zero88/schedulerx/impl/AbstractScheduler.java
@@ -28,7 +28,6 @@ import io.github.zero88.schedulerx.TimeoutPolicy;
 import io.github.zero88.schedulerx.WorkerExecutorFactory;
 import io.github.zero88.schedulerx.trigger.Trigger;
 import io.github.zero88.schedulerx.trigger.TriggerCondition.ReasonCode;
-import io.github.zero88.schedulerx.trigger.TriggerCondition.TriggerStatus;
 import io.github.zero88.schedulerx.trigger.TriggerContext;
 import io.github.zero88.schedulerx.trigger.TriggerEvaluator;
 import io.github.zero88.schedulerx.trigger.rule.TriggerRule;
@@ -251,8 +250,8 @@ public abstract class AbstractScheduler<IN, OUT, T extends Trigger> implements S
     protected final Future<TriggerContext> onEvaluationBeforeTrigger(WorkerExecutor worker, TriggerContext ctx) {
         return executeBlocking(worker, p -> {
             log(Instant.now(), "On before trigger");
-            this.wrapTimeout(timeoutPolicy().evaluationTimeout(), p)
-                .handle(evaluator.beforeTrigger(trigger, ctx, jobData.externalId()));
+            wrapTimeout(timeoutPolicy().evaluationTimeout(), p).handle(
+                evaluator.beforeTrigger(trigger, ctx, jobData.externalId()));
         });
     }
 
@@ -373,10 +372,7 @@ public abstract class AbstractScheduler<IN, OUT, T extends Trigger> implements S
         @Override
         protected Future<TriggerContext> internalBeforeTrigger(@NotNull Trigger trigger, @NotNull TriggerContext ctx,
                                                                @Nullable Object externalId) {
-            if (!ctx.isKickoff()) {
-                throw new IllegalStateException("Trigger condition status must be " + TriggerStatus.KICKOFF);
-            }
-            return Future.succeededFuture(doCheck(ctx));
+            return Future.succeededFuture(ctx.isKickoff() ? doCheck(ctx) : ctx);
         }
 
         @NotNull

--- a/core/src/main/java/io/github/zero88/schedulerx/impl/DefaultTriggerEvaluator.java
+++ b/core/src/main/java/io/github/zero88/schedulerx/impl/DefaultTriggerEvaluator.java
@@ -36,17 +36,19 @@ public class DefaultTriggerEvaluator implements TriggerEvaluator {
                                                                @NotNull TriggerContext triggerContext,
                                                                @Nullable Object externalId) {
         return this.internalBeforeTrigger(trigger, triggerContext, externalId)
-                   .flatMap(c -> next == null ? Future.succeededFuture(c) : next.beforeTrigger(trigger, c, externalId));
+                   .flatMap(c -> next == null || !c.isReadiness()
+                                 ? Future.succeededFuture(c)
+                                 : next.beforeTrigger(trigger, c, externalId));
     }
 
     @Override
     public final @NotNull Future<TriggerContext> afterTrigger(@NotNull Trigger trigger,
                                                               @NotNull TriggerContext triggerContext,
                                                               @Nullable Object externalId, long round) {
-        // @formatter:off
-        return this.internalAfterTrigger(trigger, triggerContext, externalId, round )
-                   .flatMap(c -> next == null ? Future.succeededFuture(c) : next.afterTrigger(trigger, c, externalId, round));
-        // @formatter:on
+        return this.internalAfterTrigger(trigger, triggerContext, externalId, round)
+                   .flatMap(c -> next == null || c.isStopped()
+                                 ? Future.succeededFuture(c)
+                                 : next.afterTrigger(trigger, c, externalId, round));
     }
 
     @Override

--- a/core/src/main/java/io/github/zero88/schedulerx/trigger/AfterTriggerEvaluator.java
+++ b/core/src/main/java/io/github/zero88/schedulerx/trigger/AfterTriggerEvaluator.java
@@ -20,6 +20,8 @@ public interface AfterTriggerEvaluator {
      * @param triggerContext the trigger context
      * @param externalId     the job external id
      * @param round          the current execution round
+     * @implNote Once {@code triggerContext} status {@link TriggerContext#isStopped()} is {@code true}, the
+     *     evaluation operation is stopped immediately, means the follow evaluators will not be invoked.
      * @since 2.0.0
      */
     @NotNull Future<TriggerContext> afterTrigger(@NotNull Trigger trigger, @NotNull TriggerContext triggerContext,

--- a/core/src/main/java/io/github/zero88/schedulerx/trigger/BeforeTriggerEvaluator.java
+++ b/core/src/main/java/io/github/zero88/schedulerx/trigger/BeforeTriggerEvaluator.java
@@ -14,12 +14,18 @@ import io.vertx.core.Future;
 public interface BeforeTriggerEvaluator {
 
     /**
-     * Verify if the trigger can run before each execution round is started.
+     * Verify if the trigger can run before each execution round is started, then transition the trigger context to a
+     * desired state from {@code KICKOFF} to {@code READY} or {@code MISFIRE}.
+     * <p/>
+     * Only final state is {@code READY}, the trigger will be scheduled to execute, other states will emit a trigger
+     * misfire event.
      *
      * @param trigger        the trigger
      * @param triggerContext the trigger context
      * @param externalId     the job external id
-     * @return a future of the trigger context that is evaluated
+     * @return a future of the transition trigger context that is evaluated
+     * @implNote If the {@code triggerContext} has status {@link TriggerContext#isReadiness()} is {@code false},
+     *     the evaluation operation is stopped immediately, means the follow evaluators will not be invoked.
      */
     @NotNull Future<TriggerContext> beforeTrigger(@NotNull Trigger trigger, @NotNull TriggerContext triggerContext,
                                                   @Nullable Object externalId);

--- a/core/src/main/java/io/github/zero88/schedulerx/trigger/EventSchedulerImpl.java
+++ b/core/src/main/java/io/github/zero88/schedulerx/trigger/EventSchedulerImpl.java
@@ -104,8 +104,7 @@ final class EventSchedulerImpl<IN, OUT, T> extends AbstractScheduler<IN, OUT, Ev
         protected Future<TriggerContext> internalBeforeTrigger(@NotNull Trigger trigger, @NotNull TriggerContext ctx,
                                                                @Nullable Object externalId) {
             try {
-                if (ctx.condition().status() == TriggerCondition.TriggerStatus.READY &&
-                    !((EventTrigger<T>) trigger).getPredicate().test((T) ctx.info())) {
+                if (!((EventTrigger<T>) trigger).getPredicate().test((T) ctx.info())) {
                     return Future.succeededFuture(TriggerContextFactory.skip(ctx, ReasonCode.CONDITION_IS_NOT_MATCHED));
                 }
             } catch (Exception ex) {

--- a/core/src/main/java/io/github/zero88/schedulerx/trigger/TriggerContext.java
+++ b/core/src/main/java/io/github/zero88/schedulerx/trigger/TriggerContext.java
@@ -62,6 +62,11 @@ public interface TriggerContext extends HasTriggerType {
     default boolean isReady() { return TriggerStatus.READY == condition().status(); }
 
     /**
+     * Check whether the trigger is in kick-off state or ready
+     */
+    default boolean isReadiness() { return isKickoff() || isReady(); }
+
+    /**
      * Check whether the trigger is executed or not.
      */
     default boolean isExecuted() { return TriggerStatus.EXECUTED == condition().status(); }

--- a/core/src/test/java/io/github/zero88/schedulerx/trigger/EventSchedulerTest.java
+++ b/core/src/test/java/io/github/zero88/schedulerx/trigger/EventSchedulerTest.java
@@ -67,6 +67,7 @@ class EventSchedulerTest {
             Assertions.assertEquals("UnexpectedError", condition.reasonCode());
             Assertions.assertNotNull(err);
             Assertions.assertInstanceOf(RuntimeException.class, err);
+            Assertions.assertEquals("failed in convert", err.getMessage());
         });
         final Arguments arg4 = arguments(EventTriggerPredicate.create(o -> {
             if ("1".equals(o))
@@ -78,6 +79,7 @@ class EventSchedulerTest {
             Assertions.assertEquals("UnexpectedError", condition.reasonCode());
             Assertions.assertNotNull(err);
             Assertions.assertInstanceOf(IllegalArgumentException.class, err);
+            Assertions.assertEquals("Throw in test", err.getMessage());
         });
         return Stream.of(arg1, arg2, arg3, arg4);
     }


### PR DESCRIPTION
Partly resolve #93 